### PR TITLE
Clean up unused code and tighten typings

### DIFF
--- a/src/components/DirectoryBrowser.tsx
+++ b/src/components/DirectoryBrowser.tsx
@@ -172,7 +172,7 @@ export function DirectoryBrowser({ isOpen, onClose, onSelect, initialPath }: Dir
                 <span>최근 사용한 경로</span>
               </div>
               <div className="border rounded-lg p-2 bg-muted/20">
-                {recentPaths.filter(path => path !== currentPath).map((path, index) => (
+                {recentPaths.filter(path => path !== currentPath).map((path) => (
                   <button
                     key={path}
                     onClick={() => handleSelectRecentPath(path)}

--- a/src/components/StatsHeader.tsx
+++ b/src/components/StatsHeader.tsx
@@ -38,8 +38,8 @@ export const StatsHeader = ({ stats, tasks, appName }: StatsHeaderProps) => {
     }
   };
 
-  return (
-    <Card className>
+    return (
+      <Card>
       <CardContent className="py-4 px-8">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-8">

--- a/src/components/TaskFilter.tsx
+++ b/src/components/TaskFilter.tsx
@@ -16,7 +16,7 @@ interface TaskFilterProps {
   filters: FilterOptions;
   onToggleStatusFilter: (status: "pending" | "in-progress" | "done") => void;
   onTogglePriorityFilter: (priority: "low" | "medium" | "high") => void;
-  onUpdateFilter: (key: keyof FilterOptions, value: any) => void;
+  onUpdateFilter: (key: keyof FilterOptions, value: FilterOptions[keyof FilterOptions]) => void;
   onResetFilters: () => void;
   hasActiveFilters: boolean;
   totalTasks: number;

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -212,10 +212,10 @@ export const TaskTable = ({ tasks, isLoading = false }: TaskTableProps) => {
         {/* 바디 */}
         <div>
           {isLoading ? (
-            <div className="flex flex-col items-center justify-center py-16 space-y-4">
-              <CircularProgress size="large" />
-              <p className="text-sm text-muted-foreground">프로젝트 경로 변경 중...</p>
-            </div>
+              <div className="flex flex-col items-center justify-center py-16 space-y-4">
+                <CircularProgress value={0} size={64} showValue={false} />
+                <p className="text-sm text-muted-foreground">프로젝트 경로 변경 중...</p>
+              </div>
           ) : tasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 space-y-2">
               <p className="text-sm text-muted-foreground">작업이 없습니다.</p>

--- a/src/hooks/useTaskFilter.ts
+++ b/src/hooks/useTaskFilter.ts
@@ -86,7 +86,7 @@ export const useTaskFilter = (tasks: Task[]) => {
     }).filter(task => task !== null) as Task[];
   }, [tasks, searchTerm, filters]);
 
-  const updateFilter = (key: keyof FilterOptions, value: any) => {
+  const updateFilter = (key: keyof FilterOptions, value: FilterOptions[keyof FilterOptions]) => {
     setFilters(prev => ({
       ...prev,
       [key]: value

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'

--- a/src/utils/claude-terminal.d.ts
+++ b/src/utils/claude-terminal.d.ts
@@ -1,0 +1,4 @@
+export class ClaudeTerminalRenderer {
+  renderOutput(screen: unknown, container: HTMLElement): void;
+  clear(container: HTMLElement): void;
+}

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -1,6 +1,6 @@
 type WebSocketMessage = {
   type: string;
-  data?: any;
+  data?: unknown;
   timestamp?: string;
   message?: string;
 };
@@ -19,10 +19,13 @@ export class WebSocketClient {
   private reconnectTimeout: NodeJS.Timeout | null = null;
   private pingInterval: NodeJS.Timeout | null = null;
   private pongTimeout: NodeJS.Timeout | null = null;
-  private messageQueue: Array<{type: string, data?: any}> = [];
+  private messageQueue: Array<{type: string, data?: unknown}> = [];
   private maxQueueSize = 100;
+  private url: string;
 
-  constructor(private url: string = 'ws://localhost:5001') {}
+  constructor(url: string = 'ws://localhost:5001') {
+    this.url = url;
+  }
 
   connect(): Promise<void> {
     if (this.isConnecting || (this.ws && this.ws.readyState === WebSocket.CONNECTING)) {
@@ -181,7 +184,7 @@ export class WebSocketClient {
     }
   }
 
-  private queueMessage(type: string, data?: any): void {
+  private queueMessage(type: string, data?: unknown): void {
     if (this.messageQueue.length >= this.maxQueueSize) {
       // Remove oldest message to make room
       this.messageQueue.shift();
@@ -219,11 +222,11 @@ export class WebSocketClient {
     }
   }
 
-  private emit(type: string, data: any): void {
+  private emit(type: string, data: unknown): void {
     this.handleMessage({ type, data });
   }
 
-  send(type: string, data?: any): boolean {
+  send(type: string, data?: unknown): boolean {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       try {
         this.ws.send(JSON.stringify({ type, data }));


### PR DESCRIPTION
## Summary
- remove unused state and handlers in Automation component
- tighten filter typings and streamline utility types
- fix various type errors and missing modules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953ab31b74832681cb49a91f9b188d